### PR TITLE
fix: rename repo references rtsp_curl → rtsp-curl, add test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Install package and test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ".[dev]" pytest
+          pip install -e . pytest
 
       - name: Run tests
-        run: pytest --tb=short
+        run: pytest tests/ -v --tb=short
 
   build:
     name: Build distribution

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/project/rtsp_curl/
+      url: https://pypi.org/project/rtsp-curl/
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -49,7 +49,7 @@ jobs:
           path: dist/
 
       # Uses PyPI Trusted Publisher (OIDC) — configure at:
-      # https://pypi.org/manage/project/rtsp_curl/settings/publishing/
+      # https://pypi.org/manage/project/rtsp-curl/settings/publishing/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: testpypi
-      url: https://test.pypi.org/project/rtsp_curl/
+      url: https://test.pypi.org/project/rtsp-curl/
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+.pytest_cache/
+*.sdp

--- a/README.md
+++ b/README.md
@@ -1,59 +1,66 @@
-#### Convert rtsp.c to rtsp_curl.py 
-![](https://travis-ci.org/madyel/rtsp_curl.svg?branch=master) ![](https://img.shields.io/github/license/madyel/rtsp_curl.svg) ![](https://img.shields.io/github/last-commit/madyel/rtsp_curl.svg)
+#### rtsp-curl — Python RTSP client built on libcurl
 
-A basic RTSP transfer [rtsp.c][1]
+![](https://img.shields.io/github/license/madyel/rtsp-curl.svg)
+![](https://img.shields.io/github/last-commit/madyel/rtsp-curl.svg)
+![](https://img.shields.io/pypi/v/rtsp-curl.svg)
+
+A Python RTSP client ported from [rtsp.c][1] using [pycurl](https://pypi.org/project/pycurl/).
 
 ---
 
-Example:
-
+### Install
 
 ```
+pip install rtsp-curl
+```
+
+<em>macOS (custom OpenSSL):</em>
+
+```
+PYCURL_SSL_LIBRARY=openssl \
+  LDFLAGS="-L/usr/local/opt/openssl/lib" \
+  CPPFLAGS="-I/usr/local/opt/openssl/include" \
+  pip install --no-cache-dir pycurl
+pip install rtsp-curl
+```
+
+---
+
+### Example
+
+```python
 import time
-from madyel import Rtsp_Curl
+from madyel import RtspCurl
 
 stream_uri = 'rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov'
-rtsp = Rtsp_Curl()
-rtsp.init(stream_uri, 'username:password')
-rtsp.auth()
-rtsp.rtsp_describe()
-control = rtsp.get_media_control_attribute()
-rtsp.rtsp_setup(control)
-rtsp.rtsp_play(stream_uri)
+
+client = RtspCurl()
+client.init(stream_uri, 'username:password')
+client.rtsp_options()
+client.auth()
+client.rtsp_describe()
+control = client.get_media_control_attribute()
+client.rtsp_setup(control)
+client.rtsp_play(stream_uri)
 
 time.sleep(5)
 
-rtsp.rtsp_teardown()
-rtsp.rtsp_curl_close()
-
+client.rtsp_teardown()
+client.rtsp_curl_close()
 ```
 
-##### Install_requires
+---
 
-```
-pip install scanf 
-pip install pycurl
-```
-<em>for macOS</em>:
-```
-PYCURL_SSL_LIBRARY=openssl LDFLAGS="-L/usr/local/opt/openssl/lib" CPPFLAGS="-I/usr/local/opt/openssl/include" pip install --no-cache-dir pycurl
-```
+### Publish a new version to PyPI
 
-```
-/\
-||_____-----_____-----_____
-||   O                  O  \
-||    O\\    ___    //O    /
-||       \\ /   \//        \
-||         |_O O_|         /
-||          ^ | ^          \
-||        // UUU \\        /
-||    O//            \\O   \
-||   O                  O  /
-||_____-----_____-----_____\
-||
-||.           
+Tag the release — GitHub Actions handles the rest:
 
+```bash
+git tag v0.9.1
+git push origin v0.9.1
 ```
 
-[1]: [https://curl.haxx.se/libcurl/c/rtsp.html]
+> Configure the PyPI Trusted Publisher once at:
+> https://pypi.org/manage/project/rtsp-curl/settings/publishing/
+
+[1]: https://curl.haxx.se/libcurl/c/rtsp.html

--- a/madyel/rtsp_curl.py
+++ b/madyel/rtsp_curl.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 import logging
-import os
 import random
 import time
 from pathlib import Path
-from typing import Optional, Tuple
 
 import pycurl
 from scanf import scanf
@@ -23,7 +21,7 @@ _SDP_PATH = Path(__file__).resolve().parent / "file_tmp.sdp"
 __all__ = ["RtspCurl", "Storage"]
 
 
-def _random_port_pair(low: int = 49152, high: int = 65534) -> Tuple[int, int]:
+def _random_port_pair(low: int = 49152, high: int = 65534) -> tuple[int, int]:
     """Return a consecutive (even, odd) port pair in the ephemeral range."""
     port = random.randint(low, high - 1)
     if port % 2 != 0:
@@ -73,7 +71,7 @@ class RtspCurl:
         """
         self.debug = debug
         self.tcp = tcp
-        self._curl: Optional[pycurl.Curl] = None
+        self._curl: pycurl.Curl | None = None
         self._sdp_file = None
         self._sdp_path = _SDP_PATH
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.backends.legacy:build"
 
 [project]
-name = "rtsp_curl"
+name = "rtsp-curl"
 version = "0.9.0"
 description = "Python RTSP client built on libcurl (pycurl)"
 readme = "README.md"
@@ -29,9 +29,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/madyel/rtsp_curl"
-Repository = "https://github.com/madyel/rtsp_curl"
-"Bug Tracker" = "https://github.com/madyel/rtsp_curl/issues"
+Homepage = "https://github.com/madyel/rtsp-curl"
+Repository = "https://github.com/madyel/rtsp-curl"
+"Bug Tracker" = "https://github.com/madyel/rtsp-curl/issues"
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -47,3 +47,4 @@ ignore = ["E501"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "-v --tb=short"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel"]
-build-backend = "setuptools.backends.legacy:build"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "rtsp-curl"

--- a/tests/test_rtsp_curl.py
+++ b/tests/test_rtsp_curl.py
@@ -1,0 +1,180 @@
+"""Unit tests for madyel.rtsp_curl (no live RTSP server required)."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from madyel import RtspCurl, Storage, __version__
+
+
+# ---------------------------------------------------------------------------
+# Version
+# ---------------------------------------------------------------------------
+
+class TestVersion:
+    def test_version_string(self):
+        assert isinstance(__version__, str)
+        parts = __version__.split(".")
+        assert len(parts) == 3
+        assert all(p.isdigit() for p in parts)
+
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+
+class TestStorage:
+    def test_empty(self):
+        s = Storage()
+        assert str(s) == ""
+        assert s.line == 0
+
+    def test_single_store(self):
+        s = Storage()
+        s.store(b"hello\n")
+        assert s.line == 1
+        assert "hello" in str(s)
+
+    def test_multiple_stores(self):
+        s = Storage()
+        s.store(b"line1\n")
+        s.store(b"line2\n")
+        assert s.line == 2
+        text = str(s)
+        assert "line1" in text
+        assert "line2" in text
+
+
+# ---------------------------------------------------------------------------
+# RtspCurl — initialisation
+# ---------------------------------------------------------------------------
+
+class TestRtspCurlInit:
+    def test_requires_init_before_methods(self):
+        client = RtspCurl()
+        with pytest.raises(RuntimeError, match="init()"):
+            client.auth()
+
+    def test_requires_init_before_options(self):
+        client = RtspCurl()
+        with pytest.raises(RuntimeError, match="init()"):
+            client.rtsp_options()
+
+    @patch("madyel.rtsp_curl.pycurl.Curl")
+    def test_init_sets_url(self, MockCurl):
+        mock_curl = MagicMock()
+        MockCurl.return_value = mock_curl
+
+        client = RtspCurl()
+        client.init("rtsp://192.0.2.1/stream", "user:pass")
+
+        assert client.url == "rtsp://192.0.2.1/stream"
+        assert client.user_pwd == "user:pass"
+
+    @patch("madyel.rtsp_curl.pycurl.Curl")
+    def test_init_allocates_even_port_pair(self, MockCurl):
+        MockCurl.return_value = MagicMock()
+        client = RtspCurl()
+        client.init("rtsp://192.0.2.1/stream", "user:pass")
+        assert client._port_f % 2 == 0
+        assert client._port_t == client._port_f + 1
+
+    @patch("madyel.rtsp_curl.pycurl.Curl")
+    def test_init_udp_transport(self, MockCurl):
+        MockCurl.return_value = MagicMock()
+        client = RtspCurl(tcp=False)
+        client.init("rtsp://192.0.2.1/stream", "user:pass")
+        assert client.transport.startswith("RTP/AVP")
+
+    @patch("madyel.rtsp_curl.pycurl.Curl")
+    def test_init_tcp_transport(self, MockCurl):
+        MockCurl.return_value = MagicMock()
+        client = RtspCurl(tcp=True)
+        client.init("rtsp://192.0.2.1/stream", "user:pass")
+        assert client.transport.startswith("RTSP")
+
+    @patch("madyel.rtsp_curl.pycurl.Curl")
+    def test_close_clears_handle(self, MockCurl):
+        mock_curl = MagicMock()
+        MockCurl.return_value = mock_curl
+        client = RtspCurl()
+        client.init("rtsp://192.0.2.1/stream", "user:pass")
+        client.rtsp_curl_close()
+        assert client._curl is None
+        mock_curl.close.assert_called_once()
+
+    def test_double_close_is_safe(self):
+        client = RtspCurl()
+        client.rtsp_curl_close()  # never initialised — should not raise
+
+
+# ---------------------------------------------------------------------------
+# RtspCurl — SDP parsing
+# ---------------------------------------------------------------------------
+
+class TestGetMediaControlAttribute:
+    def _make_client_with_sdp(self, sdp_content: str) -> RtspCurl:
+        client = RtspCurl()
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".sdp", delete=False, encoding="utf-8"
+        ) as fh:
+            fh.write(sdp_content)
+            client._sdp_path = Path(fh.name)
+        return client
+
+    def teardown_method(self, _method):
+        # Clean up any temp files created during the test
+        pass
+
+    def test_returns_media_control(self):
+        sdp = (
+            "v=0\n"
+            "o=- 0 0 IN IP4 127.0.0.1\n"
+            "s=Test\n"
+            "a=control:*\n"
+            "m=video 0 RTP/AVP 96\n"
+            "a=control:trackID=1\n"
+        )
+        client = self._make_client_with_sdp(sdp)
+        try:
+            assert client.get_media_control_attribute() == "trackID=1"
+        finally:
+            os.unlink(client._sdp_path)
+
+    def test_raises_when_only_session_control(self):
+        sdp = "a=control:*\n"
+        client = self._make_client_with_sdp(sdp)
+        try:
+            with pytest.raises(ValueError, match="No media-level"):
+                client.get_media_control_attribute()
+        finally:
+            os.unlink(client._sdp_path)
+
+    def test_raises_when_sdp_missing(self):
+        client = RtspCurl()
+        client._sdp_path = Path("/nonexistent/no_such_file.sdp")
+        with pytest.raises(FileNotFoundError):
+            client.get_media_control_attribute()
+
+
+# ---------------------------------------------------------------------------
+# RtspCurl — write SDP callback
+# ---------------------------------------------------------------------------
+
+class TestWriteSdp:
+    def test_write_sdp_writes_to_open_file(self):
+        client = RtspCurl()
+        mock_file = MagicMock()
+        client._sdp_file = mock_file
+        client._write_sdp(b"v=0\n")
+        mock_file.write.assert_called_once_with("v=0\n")
+
+    def test_write_sdp_no_file_does_not_raise(self):
+        client = RtspCurl()
+        client._sdp_file = None
+        client._write_sdp(b"v=0\n")  # should be a no-op

--- a/tests/test_rtsp_curl.py
+++ b/tests/test_rtsp_curl.py
@@ -5,16 +5,16 @@ from __future__ import annotations
 import os
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from madyel import RtspCurl, Storage, __version__
 
-
 # ---------------------------------------------------------------------------
 # Version
 # ---------------------------------------------------------------------------
+
 
 class TestVersion:
     def test_version_string(self):
@@ -27,6 +27,7 @@ class TestVersion:
 # ---------------------------------------------------------------------------
 # Storage
 # ---------------------------------------------------------------------------
+
 
 class TestStorage:
     def test_empty(self):
@@ -53,6 +54,7 @@ class TestStorage:
 # ---------------------------------------------------------------------------
 # RtspCurl — initialisation
 # ---------------------------------------------------------------------------
+
 
 class TestRtspCurlInit:
     def test_requires_init_before_methods(self):
@@ -117,6 +119,7 @@ class TestRtspCurlInit:
 # RtspCurl — SDP parsing
 # ---------------------------------------------------------------------------
 
+
 class TestGetMediaControlAttribute:
     def _make_client_with_sdp(self, sdp_content: str) -> RtspCurl:
         client = RtspCurl()
@@ -165,6 +168,7 @@ class TestGetMediaControlAttribute:
 # ---------------------------------------------------------------------------
 # RtspCurl — write SDP callback
 # ---------------------------------------------------------------------------
+
 
 class TestWriteSdp:
     def test_write_sdp_writes_to_open_file(self):


### PR DESCRIPTION
- Update all GitHub URLs and PyPI project URLs to rtsp-curl
- Rename package name in pyproject.toml to rtsp-curl
- Update git remote to madyel/rtsp-curl
- Add .gitignore (exclude __pycache__, dist, build, *.sdp)
- Add tests/test_rtsp_curl.py with 17 unit tests covering: • Version format validation • Storage accumulation • RtspCurl init guards (_require_init) • Port pair allocation (even/odd, UDP vs TCP transport) • Debug/close behaviour • SDP parsing (media control attribute extraction) • _write_sdp callback
- Update CI workflow: install package with -e ., run pytest tests/ -v
- Add pytest addopts to pyproject.toml

https://claude.ai/code/session_01PnzsyUrXVRH3cqt4U1BRiV