### PR TITLE
docs: rewrite README with full API reference and options table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,62 @@
-#### rtsp-curl — Python RTSP client built on libcurl
+# rtsp-curl
 
-![](https://img.shields.io/github/license/madyel/rtsp-curl.svg)
-![](https://img.shields.io/github/last-commit/madyel/rtsp-curl.svg)
-![](https://img.shields.io/pypi/v/rtsp-curl.svg)
+[![PyPI version](https://img.shields.io/pypi/v/rtsp-curl.svg)](https://pypi.org/project/rtsp-curl/)
+[![Python](https://img.shields.io/pypi/pyversions/rtsp-curl.svg)](https://pypi.org/project/rtsp-curl/)
+[![License](https://img.shields.io/github/license/madyel/rtsp-curl.svg)](LICENSE)
+[![CI](https://github.com/madyel/rtsp-curl/actions/workflows/ci.yml/badge.svg)](https://github.com/madyel/rtsp-curl/actions/workflows/ci.yml)
 
-A Python RTSP client ported from [rtsp.c][1] using [pycurl](https://pypi.org/project/pycurl/).
+Python RTSP client built on [libcurl](https://curl.haxx.se/libcurl/c/rtsp.html) via [pycurl](https://pypi.org/project/pycurl/).
+Supports OPTIONS / DESCRIBE / SETUP / PLAY / TEARDOWN over UDP (default) or TCP.
 
 ---
 
-### Install
+## Requirements
 
-```
+- Python 3.9+
+- libcurl with RTSP support (`curl --version | grep rtsp`)
+- `pycurl >= 7.45.0`
+
+---
+
+## Installation
+
+```bash
 pip install rtsp-curl
 ```
 
-<em>macOS (custom OpenSSL):</em>
+**macOS** (custom OpenSSL required by pycurl):
 
-```
+```bash
 PYCURL_SSL_LIBRARY=openssl \
   LDFLAGS="-L/usr/local/opt/openssl/lib" \
   CPPFLAGS="-I/usr/local/opt/openssl/include" \
   pip install --no-cache-dir pycurl
+
 pip install rtsp-curl
 ```
 
 ---
 
-### Example
+## Quick start
 
 ```python
 import time
 from madyel import RtspCurl
 
-stream_uri = 'rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov'
+URL = "rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov"
 
 client = RtspCurl()
-client.init(stream_uri, 'username:password')
+client.init(URL, "user:password")
+
 client.rtsp_options()
 client.auth()
 client.rtsp_describe()
+
 control = client.get_media_control_attribute()
 client.rtsp_setup(control)
-client.rtsp_play(stream_uri)
+client.rtsp_play(URL)
 
-time.sleep(5)
+time.sleep(10)          # stream for 10 seconds
 
 client.rtsp_teardown()
 client.rtsp_curl_close()
@@ -51,16 +64,73 @@ client.rtsp_curl_close()
 
 ---
 
-### Publish a new version to PyPI
+## API reference
 
-Tag the release — GitHub Actions handles the rest:
+### `RtspCurl(*, debug=False, tcp=False)`
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `debug`   | bool | `False` | Enable verbose curl logging |
+| `tcp`     | bool | `False` | Use TCP transport instead of UDP |
+
+#### Methods
+
+| Method | Description |
+|--------|-------------|
+| `init(url, user_pwd)` | Initialise the curl handle. Must be called first. `user_pwd` format: `"user:password"` |
+| `rtsp_options()` | Send RTSP OPTIONS |
+| `auth()` | Perform DIGEST authentication |
+| `rtsp_describe()` | Send RTSP DESCRIBE and save the SDP response to disk |
+| `get_media_control_attribute()` | Parse the SDP and return the first media-level `a=control` value |
+| `rtsp_setup(control)` | Send RTSP SETUP for the given track control URI |
+| `rtsp_play(url)` | Send RTSP PLAY |
+| `rtsp_teardown()` | Send RTSP TEARDOWN |
+| `rtsp_curl_close()` | Close the underlying curl handle |
+
+### `Storage`
+
+Helper that accumulates pycurl callback data line by line.
+
+```python
+from madyel import Storage
+
+buf = Storage()
+# pass buf.store as pycurl WRITEFUNCTION / HEADERFUNCTION
+print(buf)   # all accumulated lines
+```
+
+---
+
+## Options
+
+**Debug mode** — enables `pycurl.VERBOSE` (full headers and timing on stderr):
+
+```python
+client = RtspCurl(debug=True)
+```
+
+**TCP transport** — by default the client negotiates RTP over UDP:
+
+```python
+client = RtspCurl(tcp=True)
+```
+
+---
+
+## Publishing a new release
+
+Tag the commit — GitHub Actions builds and uploads to PyPI automatically:
 
 ```bash
 git tag v0.9.1
 git push origin v0.9.1
 ```
 
-> Configure the PyPI Trusted Publisher once at:
+> One-time setup: configure the PyPI Trusted Publisher at
 > https://pypi.org/manage/project/rtsp-curl/settings/publishing/
 
-[1]: https://curl.haxx.se/libcurl/c/rtsp.html
+---
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
- Modern badge set (PyPI, Python versions, license, CI status)
- Requirements section (Python 3.9+, libcurl RTSP, pycurl)
- Cleaner Quick start example
- API reference table for all RtspCurl methods + Storage helper
- Separate Options section for debug/tcp flags
- Release workflow kept; removed stale HTML tags

https://claude.ai/code/session_01PnzsyUrXVRH3cqt4U1BRiV