### PR TITLE
fix: rename package from rtsp-curl to rtsp-curl-mad to match PyPI pro…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/project/rtsp-curl/
+      url: https://pypi.org/project/rtsp-curl-mad/
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -49,7 +49,7 @@ jobs:
           path: dist/
 
       # Uses PyPI Trusted Publisher (OIDC) — configure at:
-      # https://pypi.org/manage/project/rtsp-curl/settings/publishing/
+      # https://pypi.org/manage/project/rtsp-curl-mad/settings/publishing/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: testpypi
-      url: https://test.pypi.org/project/rtsp-curl/
+      url: https://test.pypi.org/project/rtsp-curl-mad/
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rtsp-curl
 
-[![PyPI version](https://img.shields.io/pypi/v/rtsp-curl.svg)](https://pypi.org/project/rtsp-curl/)
-[![Python](https://img.shields.io/pypi/pyversions/rtsp-curl.svg)](https://pypi.org/project/rtsp-curl/)
+[![PyPI version](https://img.shields.io/pypi/v/rtsp-curl-mad.svg)](https://pypi.org/project/rtsp-curl-mad/)
+[![Python](https://img.shields.io/pypi/pyversions/rtsp-curl-mad.svg)](https://pypi.org/project/rtsp-curl-mad/)
 [![License](https://img.shields.io/github/license/madyel/rtsp-curl.svg)](LICENSE)
 [![CI](https://github.com/madyel/rtsp-curl/actions/workflows/ci.yml/badge.svg)](https://github.com/madyel/rtsp-curl/actions/workflows/ci.yml)
 
@@ -21,7 +21,7 @@ Supports OPTIONS / DESCRIBE / SETUP / PLAY / TEARDOWN over UDP (default) or TCP.
 ## Installation
 
 ```bash
-pip install rtsp-curl
+pip install rtsp-curl-mad
 ```
 
 **macOS** (custom OpenSSL required by pycurl):
@@ -32,7 +32,7 @@ PYCURL_SSL_LIBRARY=openssl \
   CPPFLAGS="-I/usr/local/opt/openssl/include" \
   pip install --no-cache-dir pycurl
 
-pip install rtsp-curl
+pip install rtsp-curl-mad
 ```
 
 ---
@@ -127,7 +127,7 @@ git push origin v0.9.1
 ```
 
 > One-time setup: configure the PyPI Trusted Publisher at
-> https://pypi.org/manage/project/rtsp-curl/settings/publishing/
+> https://pypi.org/manage/project/rtsp-curl-mad/settings/publishing/
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "rtsp-curl"
+name = "rtsp-curl-mad"
 version = "0.9.0"
 description = "Python RTSP client built on libcurl (pycurl)"
 readme = "README.md"


### PR DESCRIPTION
…ject

The PyPI Trusted Publisher is configured under the project name rtsp-curl-mad. The OIDC authentication was failing because pyproject.toml declared name = "rtsp-curl", causing a mismatch.

Updated everywhere: pyproject.toml, publish.yml (environment URLs, Trusted Publisher comment), README badges and install instructions.

https://claude.ai/code/session_01PnzsyUrXVRH3cqt4U1BRiV